### PR TITLE
Small fixes and allowing for modified drops

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -5,8 +5,9 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>3.3.6</version>
+        <version>4.0.1</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>API</artifactId>

--- a/API/src/main/java/uk/antiperson/stackmob/api/entity/multiplication/IDropTools.java
+++ b/API/src/main/java/uk/antiperson/stackmob/api/entity/multiplication/IDropTools.java
@@ -4,8 +4,10 @@ import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.List;
+
 public interface IDropTools {
-    void doDrops(int deadAmount, LivingEntity dead);
+    void doDrops(int deadAmount, LivingEntity dead, List<ItemStack> drops);
 
     // Calculate a random drop amount.
     int calculateAmount(int multiplier);

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -134,6 +134,12 @@
             <artifactId>bstats-bukkit-lite</artifactId>
             <version>1.4</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
@@ -158,6 +164,12 @@
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.0.0-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.gamingmesh</groupId>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -5,8 +5,9 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>LATEST</version>
+        <version>4.0.1</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>Plugin</artifactId>
@@ -88,6 +89,11 @@
     <dependencies>
         <dependency>
             <groupId>uk.antiperson.stackmob</groupId>
+            <artifactId>API</artifactId>
+            <version>API</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.antiperson.stackmob</groupId>
             <artifactId>v1_13</artifactId>
             <version>v1_13</version>
             <type>jar</type>
@@ -101,12 +107,6 @@
             <type>jar</type>
             <scope>compile</scope>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>MPets</groupId>

--- a/Plugin/src/main/java/uk/antiperson/stackmob/entity/multiplication/DropTools.java
+++ b/Plugin/src/main/java/uk/antiperson/stackmob/entity/multiplication/DropTools.java
@@ -46,7 +46,7 @@ public class DropTools implements IDropTools {
     private Map<ItemStack, Integer> calculateDrops(int deadAmount, LivingEntity dead, List<ItemStack> drops){
         HashMap<ItemStack, Integer> toDrop = new HashMap<>();
         for(int i = 0; i < deadAmount; i++){
-            for(ItemStack stack : drops){
+            for(ItemStack stack : generateLoot(dead, drops)){
                 if(stack == null || stack.getType() == Material.AIR){
                     continue;
                 }
@@ -68,7 +68,7 @@ public class DropTools implements IDropTools {
         return toDrop;
     }
 
-    private Collection<ItemStack> generateLoot(LivingEntity dead){
+    private Collection<ItemStack> generateLoot(LivingEntity dead, List<ItemStack> drops){
         if(sm.getHookManager().isHookRegistered(PluginCompat.CUSTOMDROPS)){
             CustomDropsHook cdh = (CustomDropsHook) sm.getHookManager().getHook(PluginCompat.CUSTOMDROPS);
             if(cdh.hasCustomDrops(dead)){
@@ -80,8 +80,13 @@ public class DropTools implements IDropTools {
                 return Collections.emptySet();
             }
         }
-        LootContext lootContext = new LootContext.Builder(dead.getLocation()).lootedEntity(dead).killer(dead.getKiller()).build();
-        return ((Mob) dead).getLootTable().populateLoot(ThreadLocalRandom.current(), lootContext);
+
+        // Default to true to keep the usual behaviour
+        if (sm.getConfig().getBoolean("use-loot-table-for-drops", true)) {
+            LootContext lootContext = new LootContext.Builder(dead.getLocation()).lootedEntity(dead).killer(dead.getKiller()).build();
+            return ((Mob) dead).getLootTable().populateLoot(ThreadLocalRandom.current(), lootContext);
+        } else
+            return drops;
     }
 
     // Calculate a random drop amount.

--- a/Plugin/src/main/java/uk/antiperson/stackmob/listeners/entity/DeathEvent.java
+++ b/Plugin/src/main/java/uk/antiperson/stackmob/listeners/entity/DeathEvent.java
@@ -54,7 +54,7 @@ public class DeathEvent implements Listener {
 
     private void multiplication(LivingEntity dead, List<ItemStack> drops, int subtractAmount, int originalExperience){
         if(sm.getCustomConfig().getBoolean("multiply-drops.enabled")){
-            sm.getDropTools().doDrops(subtractAmount, dead);
+            sm.getDropTools().doDrops(subtractAmount, dead, drops);
         }
         if(sm.getCustomConfig().getBoolean("multiply-exp.enabled")){
             // double newExperience = subtractAmount * (originalExperience * sm.config.getCustomConfig().getDouble("multiply-exp-scaling", 1.0));

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -76,6 +76,11 @@ no-stack-worlds:
 # Set to 0 to disable this feature.
 dont-stack-until: 5
 
+# Use the Minecraft loot table to determine entity drops (used for multiplication).
+# If you use plugins which change mob drops (for example, spawner plugins such as EpicSpawners) then this wont
+# multiply drops unless it's disabled.
+use-loot-table-for-drops: true
+
 # If specific entities should have a waiting time before their first stack.
 # Designed for monster grinders etc.
 wait-to-stack:

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>uk.antiperson.stackmob</groupId>
     <artifactId>StackMob-2</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,44 @@
             <version>1.13.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
     </dependencies>
+
+    <build>
+        <defaultGoal>clean package</defaultGoal>
+        <finalName>${project.artifactId}</finalName>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <targetPath>.</targetPath>
+                <filtering>true</filtering>
+                <directory>${basedir}/src/main/resources/</directory>
+                <includes>
+                    <include>*</include>
+                </includes>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/v1_13/pom.xml
+++ b/v1_13/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>3.3.6</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_13/pom.xml
+++ b/v1_13/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14/pom.xml
+++ b/v1_14/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>3.3.6</version>
+        <version>4.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/v1_14/pom.xml
+++ b/v1_14/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>StackMob-2</artifactId>
         <groupId>uk.antiperson.stackmob</groupId>
-        <version>4.0.1</version>
+        <version>4.0.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Plugins which modified #getDrops were not respected with the drop multiplication. This meant that with plugins such as EpicSpawners, when you did a modified drop they were not giving the correct amount.

This has been fixed with the configuration option `use-loot-table-for-drops`